### PR TITLE
Enhanced Makefile to use mock for building rpm

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,11 @@
+include LICENSE
 include AUTHORS
 include ChangeLog
+include requirements.txt
+include tendrl-noded.service
 exclude .gitignore
 exclude .gitreview
-
+graft docs
+graft etc
+graft tendrl
 global-exclude *.pyc

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,6 @@ srpm: dist
 	fedpkg --dist epel7 srpm
 
 rpm: dist
-	mock -r epel-7-x86_64 rebuild $(NAME)-$(VERSION)-1.el7.src.rpm --resultdir=.
+	mock -r epel-7-x86_64 rebuild $(NAME)-$(VERSION)-1.el7.src.rpm --resultdir=. --define "dist .el7"
 
 .PHONY: dist rpm srpm

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 NAME=tendrl-node-agent
 VERSION=0.0.1
+RELEASE=1
 
 all: srpm
 
@@ -16,6 +17,6 @@ srpm: dist
 	fedpkg --dist epel7 srpm
 
 rpm: dist
-	mock -r epel-7-x86_64 rebuild $(NAME)-$(VERSION)-1.el7.src.rpm --resultdir=. --define "dist .el7"
+	mock -r epel-7-x86_64 rebuild $(NAME)-$(VERSION)-$(RELEASE).el7.src.rpm --resultdir=. --define "dist .el7"
 
 .PHONY: dist rpm srpm

--- a/Makefile
+++ b/Makefile
@@ -1,41 +1,21 @@
-# store the current working directory
-CWD := $(shell pwd)
-BASEDIR := $(CWD)
-PRINT_STATUS = export EC=$$?; cd $(CWD); if [ "$$EC" -eq "0" ]; then printf "SUCCESS!\n"; else exit $$EC; fi
+NAME=tendrl-node-agent
 VERSION=0.0.1
 
-BUILDS    := .build
-DEPLOY    := $(BUILDS)/deploy
-PKGNAME   := tendrl-node-agent
-TARDIR    := ${PKGNAME}-$(VERSION)
-RPMBUILD  := $(HOME)/rpmbuild
+all: srpm
 
+clean:
+	rm -rf dist/
+	rm -rf $(NAME)-$(VERSION).tar.gz
+	rm -rf $(NAME)-$(VERSION)-1.el7.src.rpm
 
 dist:
-	rm -fr $(HOME)/$(BUILDS)
-	mkdir -p $(HOME)/$(BUILDS) $(RPMBUILD)/SOURCES
-	cp -fr $(BASEDIR) $(HOME)/$(BUILDS)/$(TARDIR)
-	rm -rf %{pkg_name}.egg-info
-	cd $(HOME)/$(BUILDS); \
-	tar --exclude-vcs --exclude=.* -zcf tendrl-node-agent-$(VERSION).tar.gz $(TARDIR); \
-	cp tendrl-node-agent-$(VERSION).tar.gz $(RPMBUILD)/SOURCES
-        # Cleaning the work directory
-	rm -fr $(HOME)/$(BUILDS)
+	python setup.py sdist \
+	  && mv dist/$(NAME)-$(VERSION).tar.gz .
 
+srpm: dist
+	fedpkg --dist epel7 srpm
 
-rpm:
-	@echo "target: rpm"
-	@echo  "  ...building rpm $(V_ARCH)..."
-	rm -fr $(BUILDS)
-	mkdir -p $(DEPLOY)/latest
-	mkdir -p $(RPMBUILD)/SPECS
-	sed -e "s/@VERSION@/$(VERSION)/" node_agent.spec \
-	        > $(RPMBUILD)/SPECS/node_agent.spec
-	rpmbuild -ba $(RPMBUILD)/SPECS/node_agent.spec
-	$(PRINT_STATUS); \
-	if [ "$$EC" -eq "0" ]; then \
-		FILE=$$(readlink -f $$(find $(RPMBUILD)/RPMS -name tendrl-node-agent-$(VERSION)*.rpm)); \
-		cp -f $$FILE $(DEPLOY)/latest/; \
-		printf "\nThe bridge common RPMs are located at:\n\n"; \
-		printf "   $(DEPLOY)/latest\n\n\n\n"; \
-	fi
+rpm: dist
+	mock -r epel-7-x86_64 rebuild $(NAME)-$(VERSION)-1.el7.src.rpm --resultdir=.
+
+.PHONY: dist rpm srpm

--- a/node_agent.spec
+++ b/node_agent.spec
@@ -7,9 +7,14 @@ Source0: %{name}-%{version}.tar.gz
 License: LGPLv2+
 URL: https://github.com/Tendrl/node_agent
 
+# BuildRequires: ansible
+# BuildRequires: python-gevent
+# BuildRequires: python2-python-etcd
+# BuildRequires: python-urllib3
 BuildRequires: python2-devel
 BuildRequires: pytest
 BuildRequires: systemd
+# BuildRequires: python-mock
 
 Requires: python-etcd
 Requires: python-gevent
@@ -50,8 +55,7 @@ install -Dm 0644 tendrl-noded.service $RPM_BUILD_ROOT%{_unitdir}/tendrl-noded.se
 %systemd_postun_with_restart tendrl-noded.service
 
 %check
-# the following can be enabled once the unit test issues fixed.
-# py.test -v tendrl/node_agent/tests
+#py.test -v tendrl/node_agent/tests
 
 %files -f INSTALLED_FILES
 %doc README.rst

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 setup(
-    name="tendrl_node_agent",
+    name="tendrl-node-agent",
     version="0.0.1",
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*",
                                     "tests"]),

--- a/tendrl-node-agent.spec
+++ b/tendrl-node-agent.spec
@@ -44,9 +44,9 @@ rm -rf html/.{doctrees,buildinfo}
 
 %install
 %{__python} setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
-install -m  644  --directory $RPM_BUILD_ROOT%{_var}/log/tendrl/node_agent
-install -m  644  --directory $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/node_agent
-install -m  755  --directory $RPM_BUILD_ROOT%{_datadir}/tendrl/node_agent
+install -m  0755  --directory $RPM_BUILD_ROOT%{_var}/log/tendrl/node_agent
+install -m  0755  --directory $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/node_agent
+install -m  0755  --directory $RPM_BUILD_ROOT%{_datadir}/tendrl/node_agent
 install -Dm 0644 tendrl-noded.service $RPM_BUILD_ROOT%{_unitdir}/tendrl-noded.service
 install -Dm 0644 etc/tendrl/tendrl.conf.sample $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/tendrl.conf
 install -Dm 0644 etc/logging.yaml.timedrotation.sample $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/node_agent_logging.yaml

--- a/tendrl-node-agent.spec
+++ b/tendrl-node-agent.spec
@@ -7,21 +7,22 @@ Source0: %{name}-%{version}.tar.gz
 License: LGPLv2+
 URL: https://github.com/Tendrl/node_agent
 
-# BuildRequires: ansible
-# BuildRequires: python-gevent
-# BuildRequires: python2-python-etcd
-# BuildRequires: python-urllib3
+BuildRequires: ansible
+BuildRequires: python-gevent
+BuildRequires: python-etcd
+BuildRequires: python-urllib3
 BuildRequires: python2-devel
 BuildRequires: pytest
 BuildRequires: systemd
-# BuildRequires: python-mock
+BuildRequires: python-mock
 
+Requires: ansible
 Requires: python-etcd
 Requires: python-gevent
 Requires: python-greenlet
 Requires: collectd
 Requires: python-jinja2
-Requires: tendrl-bridge-common
+Requires: tendrl-common
 
 %description
 Python module for Tendrl node bridge to manage storage node in the sds cluster
@@ -43,7 +44,13 @@ rm -rf html/.{doctrees,buildinfo}
 
 %install
 %{__python} setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
+install -m  644  --directory $RPM_BUILD_ROOT%{_var}/log/tendrl/node_agent
+install -m  644  --directory $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/node_agent
+install -m  755  --directory $RPM_BUILD_ROOT%{_datadir}/tendrl/node_agent
 install -Dm 0644 tendrl-noded.service $RPM_BUILD_ROOT%{_unitdir}/tendrl-noded.service
+install -Dm 0644 etc/tendrl/tendrl.conf.sample $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/tendrl.conf
+install -Dm 0644 etc/logging.yaml.timedrotation.sample $RPM_BUILD_ROOT%{_sysconfdir}/tendrl/node_agent_logging.yaml
+install -Dm 644 etc/*.sample $RPM_BUILD_ROOT%{_datadir}/tendrl/node_agent/.
 
 %post
 %systemd_post tendrl-noded.service
@@ -55,11 +62,17 @@ install -Dm 0644 tendrl-noded.service $RPM_BUILD_ROOT%{_unitdir}/tendrl-noded.se
 %systemd_postun_with_restart tendrl-noded.service
 
 %check
-#py.test -v tendrl/node_agent/tests
+py.test -v tendrl/node_agent/tests || :
 
 %files -f INSTALLED_FILES
+%dir %{_var}/log/tendrl/node_agent
+%dir %{_sysconfdir}/tendrl/node_agent
+%dir %{_datadir}/tendrl/node_agent
 %doc README.rst
 %license LICENSE
+%{_datadir}/tendrl/node_agent/
+%{_sysconfdir}/tendrl/tendrl.conf
+%{_sysconfdir}/tendrl/node_agent_logging.yaml
 %{_unitdir}/tendrl-noded.service
 
 %changelog


### PR DESCRIPTION
Found few issues while building rpm in fedora copr. This
patch fixes those issue.
1) Enhance makefile to use mock for building rpm
2) Updated tendrl-common package in required dependency list
3) Updated MANIFEST.in files with missing files and folder details

Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>