### PR TITLE
Node-agent: Add option in tendrl-config file to specify package type

### DIFF
--- a/etc/tendrl/tendrl.conf.sample
+++ b/etc/tendrl/tendrl.conf.sample
@@ -16,3 +16,6 @@ log_level = DEBUG
 log_level = DEBUG
 tendrl_exe_file_prefix = /tmp/.tendrl_runner
 log_cfg_path = /etc/tendrl/node_agent_logging.yaml
+
+# deployment type can be either "production" or "dev"
+deployment_type = production

--- a/tendrl/node_agent/ceph_integration/flows/import_cluster.py
+++ b/tendrl/node_agent/ceph_integration/flows/import_cluster.py
@@ -2,7 +2,10 @@ import json
 import socket
 import uuid
 
+from tendrl.node_agent.config import TendrlConfig
 from tendrl.node_agent.flows.flow import Flow
+
+config = TendrlConfig()
 
 
 class ImportCluster(Flow):
@@ -27,8 +30,14 @@ class ImportCluster(Flow):
                                            json.dumps(job))
         if self.node_id in node_list:
             self.parameters['fqdn'] = socket.getfqdn()
-            ceph = "git+https://github.com/Tendrl/ceph_integration.git@v1.0"
-            self.parameters['Package.name'] = ceph
+            if config.get("node_agent", "deployment_type") == "production":
+                self.parameters['Package.name'] = "tendrl-ceph-integration"
+                self.parameters['Package.pkg_type'] = "yum"
+            else:
+                ceph = "git+https://github.com/Tendrl/" \
+                       "ceph_integration.git@v1.0"
+                self.parameters['Package.name'] = ceph
+
             self.parameters['Node.cmd_str'] = "tendrl-ceph-integration " \
                                               "--cluster-id %s" % \
                                               self.cluster_id

--- a/tendrl/node_agent/gluster_integration/flows/import_cluster.py
+++ b/tendrl/node_agent/gluster_integration/flows/import_cluster.py
@@ -2,7 +2,10 @@ import json
 import socket
 import uuid
 
+from tendrl.node_agent.config import TendrlConfig
 from tendrl.node_agent.flows.flow import Flow
+
+config = TendrlConfig()
 
 
 class ImportCluster(Flow):
@@ -24,9 +27,13 @@ class ImportCluster(Flow):
                                            json.dumps(job))
         if self.node_id in node_list:
             self.parameters['fqdn'] = socket.getfqdn()
-            gluster = "git+https://github.com/Tendrl/gluster_integration.git" \
-                      "@v1.0"
-            self.parameters['Package.name'] = gluster
+            if config.get("node_agent", "deployment_type") == "production":
+                self.parameters['Package.name'] = "tendrl-gluster-integration"
+                self.parameters['Package.pkg_type'] = "yum"
+            else:
+                gluster = "git+https://github.com/Tendrl/" \
+                          "gluster_integration.git@v1.0"
+                self.parameters['Package.name'] = gluster
             self.parameters['Node.cmd_str'] = "tendrl-gluster-integration " \
                                               "--cluster-id %s" % \
                                               self.cluster_id


### PR DESCRIPTION
This patch adds a config option in tendrl.conf to specify the deployment
type. The possible options are "production" and "dev". For now this
deployment type is used to figure out whether to use rpm based
installation or pip based installation of packages during import cluster.

Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>