### PR TITLE
Fix README.adoc file not found error on rpm build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include AUTHORS
+include README.adoc
 include ChangeLog
 include requirements.txt
 include tendrl-noded.service

--- a/tendrl-node-agent.spec
+++ b/tendrl-node-agent.spec
@@ -68,7 +68,7 @@ py.test -v tendrl/node_agent/tests || :
 %dir %{_var}/log/tendrl/node_agent
 %dir %{_sysconfdir}/tendrl/node_agent
 %dir %{_datadir}/tendrl/node_agent
-%doc README.rst
+%doc README.adoc
 %license LICENSE
 %{_datadir}/tendrl/node_agent/
 %{_sysconfdir}/tendrl/tendrl.conf


### PR DESCRIPTION
README.adoc file name recently changed from README.rst
This patch update the file name and add necessary entries
into MANIFEST.in file for building rpm.

Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>