### PR TITLE
Logged EtcdKeyNotFound exception from rpc.py

### DIFF
--- a/tendrl/node_agent/manager/rpc.py
+++ b/tendrl/node_agent/manager/rpc.py
@@ -156,6 +156,9 @@ class EtcdThread(gevent.greenlet.Greenlet):
             try:
                 LOG.info("%s run..." % self.__class__.__name__)
                 self._server.run()
+            except etcd.EtcdKeyNotFound as ex:
+                LOG.debug("Given key is not present in etcd . %s", ex)
+                self._complete.wait(self.EXCEPTION_BACKOFF)
             except Exception:
                 LOG.error(traceback.format_exc())
                 self._complete.wait(self.EXCEPTION_BACKOFF)

--- a/tendrl/node_agent/tests/test_rpc.py
+++ b/tendrl/node_agent/tests/test_rpc.py
@@ -257,3 +257,16 @@ class TestEtcdThread(object):
                             'run', mock_server_run)
 
         assert True
+
+    def test_etcdthread_error(self, monkeypatch):
+        manager = SampleManager()
+
+        def Mock_read(param):
+            if param == '/queue':
+                user_request_thread._complete.set()
+                raise etcd.EtcdKeyNotFound
+        user_request_thread = EtcdThread(manager)
+        monkeypatch.setattr(
+            user_request_thread._server.client, "read", Mock_read)
+        user_request_thread._run()
+        assert True


### PR DESCRIPTION
tendrl-bug-id:Tendrl/node_agent#94

Signed-off-by: root <gshanmug@redhat.com>