### PR TITLE
Node-agent: renamed deployment_type to installation_source_type

### DIFF
--- a/etc/tendrl/tendrl.conf.sample
+++ b/etc/tendrl/tendrl.conf.sample
@@ -17,5 +17,6 @@ log_level = DEBUG
 tendrl_exe_file_prefix = /tmp/.tendrl_runner
 log_cfg_path = /etc/tendrl/node_agent_logging.yaml
 
-# deployment type can be either "production" or "dev"
-deployment_type = production
+# installation_source_type decides how tendrl will install a software
+# the possible values are pip, rpm, deb.
+installation_source_type = rpm

--- a/tendrl/node_agent/ceph_integration/flows/import_cluster.py
+++ b/tendrl/node_agent/ceph_integration/flows/import_cluster.py
@@ -8,6 +8,15 @@ from tendrl.node_agent.flows.flow import Flow
 config = TendrlConfig()
 
 
+def get_package_name(installation_source_type):
+    if installation_source_type in ["rpm", "deb"]:
+        return "tendrl-ceph-integration"
+    else:
+        ceph = "git+https://github.com/Tendrl/" \
+               "ceph_integration.git@v1.1"
+        return ceph
+
+
 class ImportCluster(Flow):
     def run(self):
         node_list = self.parameters['Node[]']
@@ -30,14 +39,13 @@ class ImportCluster(Flow):
                                            json.dumps(job))
         if self.node_id in node_list:
             self.parameters['fqdn'] = socket.getfqdn()
-            if config.get("node_agent", "deployment_type") == "production":
-                self.parameters['Package.name'] = "tendrl-ceph-integration"
-                self.parameters['Package.pkg_type'] = "yum"
-            else:
-                ceph = "git+https://github.com/Tendrl/" \
-                       "ceph_integration.git@v1.0"
-                self.parameters['Package.name'] = ceph
-
+            installation_source_type = config.get(
+                "node_agent",
+                "installation_source_type"
+            )
+            self.parameters['Package.pkg_type'] = installation_source_type
+            self.parameters['Package.name'] = get_package_name(
+                installation_source_type)
             self.parameters['Node.cmd_str'] = "tendrl-ceph-integration " \
                                               "--cluster-id %s" % \
                                               self.cluster_id

--- a/tendrl/node_agent/gluster_integration/flows/import_cluster.py
+++ b/tendrl/node_agent/gluster_integration/flows/import_cluster.py
@@ -8,6 +8,15 @@ from tendrl.node_agent.flows.flow import Flow
 config = TendrlConfig()
 
 
+def get_package_name(installation_source_type):
+    if installation_source_type in ["rpm", "deb"]:
+        return "tendrl-gluster-integration"
+    else:
+        gluster = "git+https://github.com/Tendrl/" \
+                  "gluster_integration.git@v1.1"
+        return gluster
+
+
 class ImportCluster(Flow):
     def run(self):
         node_list = self.parameters['Node[]']
@@ -27,13 +36,13 @@ class ImportCluster(Flow):
                                            json.dumps(job))
         if self.node_id in node_list:
             self.parameters['fqdn'] = socket.getfqdn()
-            if config.get("node_agent", "deployment_type") == "production":
-                self.parameters['Package.name'] = "tendrl-gluster-integration"
-                self.parameters['Package.pkg_type'] = "yum"
-            else:
-                gluster = "git+https://github.com/Tendrl/" \
-                          "gluster_integration.git@v1.0"
-                self.parameters['Package.name'] = gluster
+            installation_source_type = config.get(
+                "node_agent",
+                "installation_source_type"
+            )
+            self.parameters['Package.pkg_type'] = installation_source_type
+            self.parameters['Package.name'] = get_package_name(
+                installation_source_type)
             self.parameters['Node.cmd_str'] = "tendrl-gluster-integration " \
                                               "--cluster-id %s" % \
                                               self.cluster_id

--- a/tendrl/node_agent/objects/package/atoms/install.py
+++ b/tendrl/node_agent/objects/package/atoms/install.py
@@ -17,7 +17,7 @@ class Install(object):
         if package_type == "pip":
             attributes["editable"] = "false"
             ansible_module_path = "core/packaging/language/pip.py"
-        elif package_type == "yum":
+        elif package_type == "rpm":
             ansible_module_path = "core/packaging/os/yum.py"
         elif package_type == "deb":
             ansible_module_path = "core/packaging/os/apt.py"

--- a/tendrl/node_agent/tests/test_import_ceph_cluster.py
+++ b/tendrl/node_agent/tests/test_import_ceph_cluster.py
@@ -1,0 +1,19 @@
+from mock import MagicMock
+import sys
+sys.modules['tendrl.node_agent.config'] = MagicMock()
+from tendrl.node_agent.ceph_integration.flows.import_cluster \
+    import get_package_name
+del sys.modules['tendrl.node_agent.config']
+
+
+class TestImportCephCluster(object):
+    def test_get_package_name_for_rpm(self):
+        actual_result = get_package_name("rpm")
+        expected_result = "tendrl-ceph-integration"
+        assert actual_result == expected_result
+
+    def test_get_package_name_for_pip(self):
+        actual_result = get_package_name("pip")
+        expected_result = "git+https://github.com/Tendrl/" \
+                          "ceph_integration.git@v1.1"
+        assert actual_result == expected_result

--- a/tendrl/node_agent/tests/test_import_gluster_cluster.py
+++ b/tendrl/node_agent/tests/test_import_gluster_cluster.py
@@ -1,0 +1,19 @@
+from mock import MagicMock
+import sys
+sys.modules['tendrl.node_agent.config'] = MagicMock()
+from tendrl.node_agent.gluster_integration.flows.import_cluster \
+    import get_package_name
+del sys.modules['tendrl.node_agent.config']
+
+
+class TestImportGlusterCluster(object):
+    def test_get_package_name_for_rpm(self):
+        actual_result = get_package_name("rpm")
+        expected_result = "tendrl-gluster-integration"
+        assert actual_result == expected_result
+
+    def test_get_package_name_for_pip(self):
+        actual_result = get_package_name("pip")
+        expected_result = "git+https://github.com/Tendrl/" \
+                          "gluster_integration.git@v1.1"
+        assert actual_result == expected_result


### PR DESCRIPTION
This PR renames deployment_type to installation_source_type in
the config file as the later is more meaningful

tendrl-spec: Tendrl/node_agent#83

Signed-off-by: nnDarshan <darshan.n.2024@gmail.com>